### PR TITLE
chore: update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rofi-plugin-sys"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.59.0"
 description = "Raw FFI bindings to Rofi's C plugin interface"
@@ -10,9 +10,9 @@ keywords = ["rofi", "plugin"]
 categories = ["external-ffi-bindings"]
 
 [dependencies]
-bitflags = "2.0.1"
-cairo-sys-rs = "0.19.2"
-glib-sys = "0.19.0"
+bitflags = "2.9.1"
+cairo-sys-rs = "0.21.0"
+glib-sys = "0.21.0"
 
 [workspace]
 members = ["examples/basic"]


### PR DESCRIPTION
Just a quick one to address [this vulnerability](https://github.com/advisories/GHSA-wrw7-89jp-8q8g) from the GitHub advisory database. Not sure how relevant it even is here but the security tab has been pestering me on `rofi-games` so figured I would just do some quick dependency updates upstream, if that's alright. I haven't seen any issues locally from updating the deps of this and `rofi-mode.rs`.